### PR TITLE
起動ロジックとインテグレーションテストの基盤を構築 (#8)

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -3,8 +3,14 @@ name = "api"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+path = "src/main.rs"
+name = "api"
 
 [dependencies]
 actix-web = "4.0.1"
-actix-rt = "2.7.0"
+secrecy = { version = "0.8.0", features = ["serde"] }
+tokio = { version = "1.18.2", features = ["macros", "rt-multi-thread"] }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -14,3 +14,6 @@ name = "api"
 actix-web = "4.0.1"
 secrecy = { version = "0.8.0", features = ["serde"] }
 tokio = { version = "1.18.2", features = ["macros", "rt-multi-thread"] }
+
+[dev-dependencies]
+reqwest = { version = "0.11", features = ["json"] }

--- a/api/src/controllers/health_check.rs
+++ b/api/src/controllers/health_check.rs
@@ -1,0 +1,7 @@
+use actix_web::HttpResponse;
+
+// Request: GET /health_check HTTP/1.1
+// Response: HTTP/1.1 200 OK, content-length: 0
+pub async fn health_check() -> HttpResponse {
+    HttpResponse::Ok().finish()
+}

--- a/api/src/controllers/index.rs
+++ b/api/src/controllers/index.rs
@@ -1,5 +1,0 @@
-use actix_web::{HttpResponse, Responder};
-
-pub async fn index() -> impl Responder {
-    HttpResponse::Ok().body("Hello world!")
-}

--- a/api/src/controllers/mod.rs
+++ b/api/src/controllers/mod.rs
@@ -1,1 +1,3 @@
-pub mod index;
+mod health_check;
+
+pub use health_check::health_check;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,2 +1,3 @@
-pub mod routes;
 pub mod controllers;
+pub mod routes;
+pub mod startup;

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,10 +1,12 @@
-use actix_web::{App, HttpServer};
-use api::routes;
+use api::startup::Application;
 
-#[actix_rt::main]
+// (仮) 設定をどこから取ってくるかは相談。
+const HOST: [u8; 4] = [127, 0, 0, 1];
+const PORT: u16 = 8080;
+
+#[tokio::main]
 async fn main() -> std::io::Result<()> {
-    HttpServer::new(|| App::new().configure(routes::routes))
-        .bind("api:8000")?
-        .run()
-        .await
+    let application = Application::build(HOST, PORT)?;
+    application.start_server().await?;
+    Ok(())
 }

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -1,6 +1,7 @@
-use actix_web::{web};
-use crate::controllers::index;
+use actix_web::web;
+
+use crate::controllers::health_check;
 
 pub fn routes(cfg: &mut web::ServiceConfig) {
-    cfg.route("/", web::get().to(index::index));
+    cfg.route("/health_check", web::get().to(health_check));
 }

--- a/api/src/startup.rs
+++ b/api/src/startup.rs
@@ -15,7 +15,7 @@ impl Application {
         let address = SocketAddr::from((host, port));
         let listener = TcpListener::bind(address)?;
         let port = listener.local_addr().unwrap().port();
-        let server = start_server(listener)?;
+        let server = build_server(listener)?;
 
         Ok(Self { port, server })
     }
@@ -29,7 +29,7 @@ impl Application {
     }
 }
 
-pub fn start_server(listener: TcpListener) -> Result<Server, std::io::Error> {
+fn build_server(listener: TcpListener) -> Result<Server, std::io::Error> {
     let server = HttpServer::new(move || App::new().configure(routes::routes))
         .listen(listener)?
         .run();

--- a/api/src/startup.rs
+++ b/api/src/startup.rs
@@ -1,0 +1,37 @@
+use std::net::{SocketAddr, TcpListener};
+
+use actix_web::dev::Server;
+use actix_web::{App, HttpServer};
+
+use crate::routes;
+
+pub struct Application {
+    port: u16,
+    server: Server,
+}
+
+impl Application {
+    pub fn build(host: [u8; 4], port: u16) -> Result<Self, std::io::Error> {
+        let address = SocketAddr::from((host, port));
+        let listener = TcpListener::bind(address)?;
+        let port = listener.local_addr().unwrap().port();
+        let server = start_server(listener)?;
+
+        Ok(Self { port, server })
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub async fn start_server(self) -> Result<(), std::io::Error> {
+        self.server.await
+    }
+}
+
+pub fn start_server(listener: TcpListener) -> Result<Server, std::io::Error> {
+    let server = HttpServer::new(move || App::new().configure(routes::routes))
+        .listen(listener)?
+        .run();
+    Ok(server)
+}

--- a/api/tests/api/health_check.rs
+++ b/api/tests/api/health_check.rs
@@ -1,0 +1,16 @@
+use crate::helpers::spawn_app;
+
+#[tokio::test]
+async fn health_check_returns_200() {
+    // Arrange
+    let app = spawn_app().await;
+    let client = reqwest::Client::new();
+
+    // Act
+    let response = client
+        .get(&format!("{}/health_check", &app.address))
+        .send()
+        .await
+        .expect("Failed to send request.");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+}

--- a/api/tests/api/helpers.rs
+++ b/api/tests/api/helpers.rs
@@ -1,0 +1,16 @@
+use api::startup::Application;
+
+pub struct TestApp {
+    pub address: String,
+    pub port: u16,
+}
+
+pub async fn spawn_app() -> TestApp {
+    let application = Application::build([127, 0, 0, 1], 0).expect("Failed to build application.");
+    let port = application.port();
+    let _ = tokio::spawn(application.start_server());
+    TestApp {
+        address: format!("http://127.0.0.1:{port}"),
+        port,
+    }
+}

--- a/api/tests/api/main.rs
+++ b/api/tests/api/main.rs
@@ -1,0 +1,2 @@
+pub mod health_check;
+pub mod helpers;


### PR DESCRIPTION
### `main.rs`
エントリーポイント。ロジックはここに書かないようにしたい。

### `startup.rs`

アプリケーションの起動に関するロジックは全てここに置く。

後々DBのコネクションを確立するようなコードもここで良いかとぞ思ふ。
`Application` 構造体で `actix_web::web::Server` を wrap して、その他の必要な情報をフィールドに持たせることで簡単に取り出せる。`port` を持たせてるのはインテグレーションテストでOSによってランダムに割り当てられたポート番号を取得するため。